### PR TITLE
Add logger and .env detection

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -52,7 +52,7 @@ _log_and_notify() {
     ;;
   esac
   echo "[$date_time][$level] $msg"
-  PAYLOAD="{ \"attachments\": [{ \"color\": \"$slack_color\", \"fields\": [{ \"title\": \"$SLACK_TITLE\", \"value\": \"$msg\" }]}] }"
+  local PAYLOAD="{ \"attachments\": [{ \"color\": \"$slack_color\", \"fields\": [{ \"title\": \"$SLACK_TITLE\", \"value\": \"$msg\" }]}] }"
   curl -X POST --silent \
     -H 'Content-type: application/json; charset=utf-8' \
     --data "$PAYLOAD" \
@@ -87,9 +87,13 @@ function ERROR() {
 	fi
 }
 
+#############################################
+# UTILS
+#############################################
+
 function checkResult() {
-  status=$?
-  message=$1
+  local status=$?
+  local message=$1
   if [ "$status" == "0" ]; then
     DEBUG "$message"
   else
@@ -99,7 +103,7 @@ function checkResult() {
 }
 
 function filterDockerComposeFiles() {
-  arr=()
+  local arr=()
   for changedFile in $1; do
     if [[ $changedFile =~ docker-compose\.ya?ml$ ]]; then
       arr+=("$changedFile")
@@ -108,11 +112,11 @@ function filterDockerComposeFiles() {
   echo arr
 }
 
-getStatus() {
+function getStatus() {
     echo "$1" | cut -f 1
 }
 
-getFileName() {
+function getFileName() {
     echo "$1" | cut -f 2
 }
 

--- a/update.sh
+++ b/update.sh
@@ -166,7 +166,7 @@ for delettedFile in "${delettedFiles[@]}"; do
     SUCCESS "Successfully deletted $delettedFile !"
 done
 
-git pull
+git pull > /dev/null
 checkResult "Pull repository"
 
 # Docker compose up files

--- a/update.sh
+++ b/update.sh
@@ -167,9 +167,15 @@ checkResult "Pull repository"
 
 # Docker compose up files
 for updatedFile in "${updatedFiles[@]}"; do
-    docker-compose -f "$updatedFile" up -d
-    checkResult "UP $updatedFile"
-    SUCCESS "Successfully deploy $updatedFile !"
+    dir=$(dirname "$updatedFile")
+
+    if [ -f "./$dir/.env.example" ] && [ ! -f "./$dir/.env" ]; then
+        ERROR ".env file needed for $dir, deploy stoped"
+    else
+        docker compose -f "$updatedFile" up -d
+        checkResult "UP $updatedFile"
+        SUCCESS "Successfully deploy $updatedFile !"
+    fi
 done
 
 

--- a/update.sh
+++ b/update.sh
@@ -1,25 +1,99 @@
 #!/bin/bash
 REMOTE_NAME=origin
-REMOTE_BRANCH=master
-LOCAL_BRANCH=master
+REMOTE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 SLACK_WEBHOOK=YOUR_SLACK_WEBHOOK
 SLACK_TITLE="Docker Deployment"
 
-notify() {
-  message="$1"
-  echo "=> $message"
-  docker run --rm -e SLACK_WEBHOOK=$SLACK_WEBHOOK -e SLACK_TITLE="$SLACK_TITLE" -e SLACK_MESSAGE="$message"  technosophos/slack-notify
+# Set the slack alert level be DEBUG | SUCCESS | ERROR | NONE
+SLACK_ALERT_LEVEL="SUCCESS"
+
+
+#############################################
+# LOGGER
+#############################################
+
+
+LOG_LEVEL_DECIMAL=0
+case "$SLACK_ALERT_LEVEL" in
+  DEBUG)
+    LOG_LEVEL_DECIMAL=3
+  ;;
+  SUCCESS)
+    LOG_LEVEL_DECIMAL=2
+  ;;
+  ERROR)
+    LOG_LEVEL_DECIMAL=1
+  ;;
+esac
+   
+_log() {
+  local date_time msg level slack_color
+  date_time=$(date +"%Y/%m/%d %H:%M:%S")
+  msg="$1"
+  level="${2-${FUNCNAME[1]}}"
+  echo "[$date_time][$level] $msg"
+}
+_log_and_notify() {
+  local date_time msg level slack_color
+  date_time=$(date +"%Y/%m/%d %H:%M:%S")
+  msg="$1"
+  level="${2-${FUNCNAME[1]}}"
+  case "$level" in
+    SUCCESS)
+      slack_color="#84cc16"
+      ;;
+    DEBUG)
+      slack_color="#0ea5e9"
+      ;;
+    *)
+      slack_color="#ef4444"
+    ;;
+  esac
+  echo "[$date_time][$level] $msg"
+  PAYLOAD="{ \"attachments\": [{ \"color\": \"$slack_color\", \"fields\": [{ \"title\": \"$SLACK_TITLE\", \"value\": \"$msg\" }]}] }"
+  curl -X POST --silent \
+    -H 'Content-type: application/json; charset=utf-8' \
+    --data "$PAYLOAD" \
+    "$SLACK_WEBHOOK" 1>/dev/null
+}
+
+function DEBUG() {
+	if [[ "$LOG_LEVEL_DECIMAL" -ge "3" ]]
+	then
+    _log_and_notify "$1"
+  else
+    _log "$1"
+	fi
+}
+
+function SUCCESS() {
+	if [[ "$LOG_LEVEL_DECIMAL" -ge "2" ]]
+	then
+    _log_and_notify "$1"
+  else
+    _log "$1"
+	fi
+}
+
+
+function ERROR() {
+	if [[ "$LOG_LEVEL_DECIMAL" -ge "1" ]]
+	then
+    _log_and_notify "$1"
+  else
+    _log "$1"
+	fi
 }
 
 function checkResult() {
   status=$?
   message=$1
   if [ "$status" == "0" ]; then
-    echo "[SUCCESS] $message"
+    DEBUG "$message"
   else
-    echo "[ ERROR ] $message"
-    notify "[ ERROR ] $message"
+    ERROR "$message"
     exit 1
   fi
 }
@@ -42,17 +116,15 @@ getFileName() {
     echo "$1" | cut -f 2
 }
 
-
-
-git remote update
+git remote update > /dev/null
 checkResult "Update Remote"
 
 if [ "$(git rev-parse HEAD)" == "$(git rev-parse @{u})" ]; then
-  echo "No changes"
+  DEBUG "No changes"
   exit 0
 fi
 
-echo "Changes detected"
+DEBUG "Changes detected"
 
 changedFiles=$(git diff --name-status $LOCAL_BRANCH $REMOTE_NAME/$REMOTE_BRANCH)
 checkResult "Update Remote"
@@ -76,18 +148,18 @@ while IFS= read -r changedFile; do
   fi
 done <<< "$changedFiles"
 
-echo "Deleted files"
-echo "${delettedFiles[@]}"
+DEBUG "Deleted files"
+DEBUG "${delettedFiles[@]}"
 
-echo "Updated files"
-echo "${updatedFiles[@]}"
+DEBUG "Updated files"
+DEBUG "${updatedFiles[@]}"
 
 
 # Docker compose down files
 for delettedFile in "${delettedFiles[@]}"; do
     docker-compose -f "$delettedFile" down
     checkResult "DOWN $delettedFile"
-    notify "Successfully deletted $delettedFile !"
+    SUCCESS "Successfully deletted $delettedFile !"
 done
 
 git pull
@@ -97,7 +169,7 @@ checkResult "Pull repository"
 for updatedFile in "${updatedFiles[@]}"; do
     docker-compose -f "$updatedFile" up -d
     checkResult "UP $updatedFile"
-    notify "Successfully deploy $updatedFile !"
+    SUCCESS "Successfully deploy $updatedFile !"
 done
 
 


### PR DESCRIPTION
## Work in the pr

* Moved from using `technosophos/slack-notify` docker container to notify slack to using `curl`, resulting in a near 10x time improvement when there is notification sent
* Add logger system with multiple level
  * Will log everything to terminal
  * You can customize the level where it sends to the slack webhook
* Some bash scoping cleanup
* Add `.env.exemple` detection, will halt deploy for the current stack if there is a `.env.exemple` present but no `.env`
* Default remote branch to git's current branch
* Default local branch to git's current branch

## Commits
The name are mostly self explanatory

- :loud_sound: add logger and cleanup console output
- :sparkles: add .env detection system
- :recycle: change scoping on local only variables
- :mute: remove git pull logs